### PR TITLE
schema fixes

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -13,12 +13,16 @@
         "required": ["affected_versions", "cpansa_id"],
         "properties": {
           "affected_versions": {
-            "type": "string"
-          },
-          "cves": {
             "type": "array",
             "minItems": 1,
             "items": {
+              "type": "string"
+            }
+          },
+          "cves": {
+            "type": "array",
+            "items": {
+              "description": "CVE id",
               "type": "string"
             }
           },
@@ -27,7 +31,6 @@
           },
           "references": {
             "type": "array",
-            "minItems": 1,
             "items": {
               "type": "string",
               "format": "uri"
@@ -38,7 +41,7 @@
             "format": "date"
           },
           "severity": {
-            "enum": ["moderate","high"]
+            "enum": ["minor", "medium", "moderate", "high", "critical"]
           }
         }
       }


### PR DESCRIPTION
- affected_versions is always an array, with at least 1 item
- cves and references are always arrays (but can have 0 items)
- add more possible values for severity